### PR TITLE
Added support for ida9.0 beta

### DIFF
--- a/plugins/patching/asm.py
+++ b/plugins/patching/asm.py
@@ -444,13 +444,13 @@ class AsmX86(KeystoneAssembler):
         'REPE CMPSW',
     ]
 
-    def __init__(self, inf):
+    def __init__(self):
         arch = keystone.KS_ARCH_X86
 
-        if inf.is_64bit():
+        if ida_ida.inf_is_64bit():
             mode = keystone.KS_MODE_64
             self.MAX_PREVIEW_BYTES = 7
-        elif inf.is_32bit():
+        elif ida_ida.inf_is_32bit_exactly():
             mode = keystone.KS_MODE_32
             self.MAX_PREVIEW_BYTES = 6
         else:
@@ -644,13 +644,13 @@ class AsmARM(KeystoneAssembler):
         # TODO: MRS and MOV (32/64 bit) are semi-supported too
     ]
 
-    def __init__(self, inf):
+    def __init__(self):
 
         # ARM64
-        if inf.is_64bit():
+        if ida_ida.inf_is_64bit():
             arch = keystone.KS_ARCH_ARM64
 
-            if inf.is_be():
+            if ida_ida.inf_is_be():
                 mode = keystone.KS_MODE_BIG_ENDIAN
             else:
                 mode = keystone.KS_MODE_LITTLE_ENDIAN

--- a/plugins/patching/asm.py
+++ b/plugins/patching/asm.py
@@ -662,7 +662,7 @@ class AsmARM(KeystoneAssembler):
         else:
             arch = keystone.KS_ARCH_ARM
 
-            if inf.is_be():
+            if ida_ida.inf_is_be():
                 mode = keystone.KS_MODE_ARM | keystone.KS_MODE_BIG_ENDIAN
                 self._ks_thumb = keystone.Ks(arch, keystone.KS_MODE_THUMB | keystone.KS_MODE_BIG_ENDIAN)
             else:
@@ -810,10 +810,10 @@ class AsmARM(KeystoneAssembler):
 
 class AsmPPC(KeystoneAssembler):
 
-    def __init__(self, inf):
+    def __init__(self):
         arch = keystone.KS_ARCH_PPC
 
-        if inf.is_64bit():
+        if ida_ida.inf_is_64bit():
             mode = keystone.KS_MODE_PPC64
         else:
             mode = keystone.KS_MODE_PPC32
@@ -831,15 +831,15 @@ class AsmPPC(KeystoneAssembler):
 
 class AsmMIPS(KeystoneAssembler):
 
-    def __init__(self, inf):
+    def __init__(self):
         arch = keystone.KS_ARCH_MIPS
 
-        if inf.is_64bit():
+        if ida_ida.inf_is_64bit():
             mode = keystone.KS_MODE_MIPS64
         else:
             mode = keystone.KS_MODE_MIPS32
 
-        if inf.is_be():
+        if ida_ida.inf_is_be():
             mode |= keystone.KS_MODE_BIG_ENDIAN
         else:
             mode |= keystone.KS_MODE_LITTLE_ENDIAN
@@ -853,15 +853,15 @@ class AsmMIPS(KeystoneAssembler):
 
 class AsmSPARC(KeystoneAssembler):
 
-    def __init__(self, inf):
+    def __init__(self):
         arch = keystone.KS_ARCH_SPARC
 
-        if inf.is_64bit():
+        if ida_ida.inf_is_64bit():
             mode = keystone.KS_MODE_SPARC64
         else:
             mode = keystone.KS_MODE_SPARC32
 
-        if inf.is_be():
+        if ida_ida.inf_is_be():
             mode |= keystone.KS_MODE_BIG_ENDIAN
         else:
             mode |= keystone.KS_MODE_LITTLE_ENDIAN
@@ -875,5 +875,5 @@ class AsmSPARC(KeystoneAssembler):
 
 class AsmSystemZ(KeystoneAssembler):
 
-    def __init__(self, inf):
+    def __init__(self):
         super(AsmSystemZ, self).__init__(keystone.KS_ARCH_SYSTEMZ, keystone.KS_MODE_BIG_ENDIAN)

--- a/plugins/patching/core.py
+++ b/plugins/patching/core.py
@@ -167,13 +167,12 @@ class PatchingCore(object):
         """
         Initialize the assembly engine to be used for patching.
         """
-        inf = ida_idaapi.get_inf_structure()
-        arch_name = inf.procname.lower()
+        arch_name = ida_ida.inf_get_procname()
 
         if arch_name == 'metapc':
-            assembler = AsmX86(inf)
+            assembler = AsmX86()
         elif arch_name.startswith('arm'):
-            assembler = AsmARM(inf)
+            assembler = AsmARM()
 
         #
         # TODO: disabled until v0.2.0
@@ -1213,8 +1212,7 @@ class PatchingCore(object):
 
         percent_truncated = percent[:percent.index('.')+3] # truncate! don't round this float...
 
-        inf = ida_idaapi.get_inf_structure()
-        arch_name = inf.procname.lower()
+        arch_name = ida_ida.inf_get_procname()
 
         total_failed = total - good
         unknown_fails = total_failed - unsupported

--- a/plugins/patching/core.py
+++ b/plugins/patching/core.py
@@ -171,7 +171,7 @@ class PatchingCore(object):
 
         if arch_name == 'metapc':
             assembler = AsmX86()
-        elif arch_name.startswith('arm'):
+        elif arch_name.startswith('arm') or arch_name.startswith('ARM'):
             assembler = AsmARM()
 
         #

--- a/plugins/patching/util/ida.py
+++ b/plugins/patching/util/ida.py
@@ -12,7 +12,6 @@ import ida_lines
 import ida_idaapi
 import ida_kernwin
 import ida_segment
-import idc
 
 from .qt import *
 from .python import swap_value
@@ -300,6 +299,9 @@ def resolve_symbol(from_ea, name):
     but the point still stands: a function like this has to be able to return
     'multiple' potential values)
     """
+
+    # XXX: deferred import to avoid breaking patching.reload() dev helper
+    import idc
 
     #
     # first, we will attempt to parse the given symbol as a global


### PR DESCRIPTION
IDA 8.x does not support get_type_by_tid, and IDA 9.0 does not support ida_struct. I don't know of a way to support both simultaneously.